### PR TITLE
An empty reporterOutput attribute allows grunt to work with jshint-stylish as reporter without generating extra files on the folder

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -9,7 +9,8 @@ module.exports = function (grunt) {
     jshint: {
       options: {
         jshintrc: '.jshintrc',
-        reporter: require('jshint-stylish')
+        reporter: require('jshint-stylish'),
+        reporterOutput: ''
       },
       gruntfile: {
         src: ['Gruntfile.js']


### PR DESCRIPTION
This is necessary to allow the tests to be run on updated grunt installations.