### PR TITLE
Fixed first argument on createConversion sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ services.dealLost(reason, null, leadId)
 ```js
 var identifier = 'action-name';
 
-conversions.createConversion('action-name', {
+conversions.createConversion(identifier, {
     email: 'email@example.com',
     nome: 'Lead name',
 }).then(function (data) {


### PR DESCRIPTION
It has a variable declared but used 'action-name' on first parameter, otherwise the identifier variable.